### PR TITLE
Readme: fix cross-reference (gfm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The incremental nature means that general tags reflect the time sequence of prot
 
 ## Fixed protocol features
 
-### Protocol-code and protocol-number {#protocol-code}
+### Protocol-code and protocol-number <a name="protocol-code"></a>
 
 A **protocol-code** consists of three characters and three digits separated by a hyphen.
 


### PR DESCRIPTION
@hansvancalster Refers to https://github.com/inbo/protocols/pull/15#issuecomment-639542977. In gfm, either one has to use the auto-generated anchor names (title-words-lowercase-hyphens), or one should use html as explained [here](https://stackoverflow.com/questions/5319754/cross-reference-named-anchor-in-markdown). As an exercise, I did the latter; it works well.