### PR TITLE
Add initial .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,35 @@
+{
+    "title": "Source code of protocols of the Research Institute for Nature and Forest (INBO)",
+    "description": "Source code of protocols used at the Research Institute for Nature and Forest (INBO), Brussels, Belgium. The protocols are written in R markdown and are compiled as html using the bookdown package. Website with compiled protocols (including older versions as well): <a href=\"https://protocols.inbo.be\">https://protocols.inbo.be</a>.",
+    "license": "GPL-3.0",
+    "upload_type": "other",
+    "access_right": "open",
+    "creators": [
+        {
+            "name": "Van Calster, Hans",
+            "affiliation": "Research Institute for Nature and Forest",
+            "orcid": "0000-0001-8595-8426"
+        },
+        {
+            "name": "Onkelinx, Thierry",
+            "affiliation": "Research Institute for Nature and Forest",
+            "orcid": "0000-0001-8804-4216"
+        },
+        {
+            "name": "Vanderhaeghe, Floris",
+            "affiliation": "Research Institute for Nature and Forest",
+            "orcid": "0000-0002-6378-6229"
+        }
+    ],
+    "keywords": [
+        "open protocol",
+        "open science",
+        "research institute",
+        "nature",
+        "forest",
+        "environment",
+        "markdown",
+        "Flanders",
+        "Belgium"
+        ]
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
     "title": "Source code of protocols of the Research Institute for Nature and Forest (INBO)",
-    "description": "Source code of protocols used at the Research Institute for Nature and Forest (INBO), Brussels, Belgium. The protocols are written in R markdown and are compiled as html using the bookdown package. Website with compiled protocols (including older versions as well): <a href=\"https://protocols.inbo.be\">https://protocols.inbo.be</a>.",
+    "description": "This archive provides the source code of protocols used at the Research Institute for Nature and Forest (INBO), Brussels, Belgium (<a href=\"https://www.inbo.be/en\">www.inbo.be</a>). The protocols are written in R markdown and are compiled as html using the bookdown package. The website with the compiled protocols (including older versions) is at <a href=\"https://protocols.inbo.be\">https://protocols.inbo.be</a>.",
     "license": "GPL-3.0",
     "upload_type": "other",
     "access_right": "open",


### PR DESCRIPTION
This PR addresses #7 (doesn't solve it yet).

Please have a careful look at the `.zenodo.json` file's contents.

- Normally all available fields under **_Deposit metadata_** at https://developers.zenodo.org/#representation should work (I expect).
- I chose `"upload_type": "other"`, but one could also choose `"publication"` (which allows for several subtypes, but not 'protocols') or `"software"` in our case.
- Will the URL indeed be https://protocols.inbo.be ?

The Zenodo Sandbox webhook has been set up without problems and github _delivers_ to Zenodo Sandbox without errors. From earlier experiences, I'm pretty sure the `.zenodo.json` file should work, also because the latest 'demo release' ('dummy' tag v0.3.0; containing this file) did not result in errors reported in the github webhook. If the file contained errors, pushing to Zenodo would not succeed and that would result in errors in the github webhook (been there).

However, Zenodo sandbox github integration currently seems broken so I could not yet test the publication success (tried this both with and without a json file BTW). See https://github.com/zenodo/zenodo/issues/2002 That remains in the to-do of #7, but it will not harm to merge already.

Further note: the `.zenodo.json` file needs to be updated before each release because **_authorship_** will extend as protocols are added. I guess this should also be added to the administrative workflow steps @hansvancalster .
