### PR TITLE
fix for failing set branch name

### DIFF
--- a/.github/workflows/generate-artifact-pr.yml
+++ b/.github/workflows/generate-artifact-pr.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Set branch name
         run: |
-          echo "branch_name=$(echo ${GITHUB_HEAD_REF})" >> $GITHUB_ENV
+          echo "branch_name=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
   
       - name: Print branch name
         run: |


### PR DESCRIPTION
reason is because GITHUB_HEAD_REF only exists for pull_request and I changed the trigger from pull_request to push
