### PR TITLE
.zenodo.json: extend authorship

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -11,6 +11,11 @@
             "orcid": "0000-0001-8595-8426"
         },
         {
+            "name": "De Bie, Els",
+            "affiliation": "Research Institute for Nature and Forest",
+            "orcid": "0000-0001-7679-743X"
+        },
+        {
             "name": "Onkelinx, Thierry",
             "affiliation": "Research Institute for Nature and Forest",
             "orcid": "0000-0001-8804-4216"


### PR DESCRIPTION
## Description

Adds @ElsDeBie to `.zenodo.json`.

The test result at Zenodo Sandbox can be seen at https://sandbox.zenodo.org/record/872719 (which also includes PR #47).

Beware that further testing at Zenodo Sandbox has now ended - has been replaced by Zenodo.

